### PR TITLE
feat(get-access-token): new auth scheme due to spotify api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # Spotify Canvas Downloader
 Tool to get Canvas cover videos from Spotify tracks.
 
+**Note**: As of late 2024, Spotify has updated their authentication system. This now requires a valid `sp_dc` cookie from your browser session.
 
 ## ✨ [Try it out](https://canvastify.delitefully.com)
+
+## 🔐 Authentication Setup
+
+Due to Spotify's updated authentication system, you'll need to provide your `sp_dc` cookie:
+
+1. **Get your sp_dc cookie:**
+   - Go to [open.spotify.com](https://open.spotify.com) in your browser
+   - Log in to your Spotify account
+   - Open Developer Tools (F12)
+   - Go to Application/Storage → Cookies → https://open.spotify.com
+   - Find the `sp_dc` cookie and copy its value
+
+2. **Set the cookie:**
+   - Add `SP_DC=your_cookie_value` to your `.env` file, or
+   - Set it as an environment variable: `export SP_DC=your_cookie_value`
 
 
 ### Building
@@ -14,6 +30,7 @@ Tool to get Canvas cover videos from Spotify tracks.
 - Configure the env variables
   ```sh
   mv env.example .env
+  # Add your SP_DC cookie to the .env file
   ```
 - Build the image using Docker Compose
   ```sh
@@ -26,6 +43,7 @@ Recompile protocol buffer proto (useful when upgrading protobuff):
 protoc ./protos/canvas.proto  --python_out=./src/
 ```
 Requires the [Protocol Buffers package](https://developers.google.com/protocol-buffers/docs/downloads).
+
 ### API
 
 ```http
@@ -39,3 +57,7 @@ Returns
     "message": string, error message if success is 'false'
 }
 ```
+
+## ⚠️ Important Notes
+
+- This tool is for educational purposes. Please respect Spotify's Terms of Service.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,7 @@ services:
     ports:
       - "8000:80"
     environment:
-      - SPOTIFY_USERNAME=${SPOTIFY_USERNAME}
-      - SPOTIFY_PASSWORD=${SPOTIFY_PASSWORD}
+      - SP_DC=${SP_DC}
       - HOST_ORIGIN=${HOST_ORIGIN}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/api/health"]

--- a/env.example
+++ b/env.example
@@ -1,1 +1,2 @@
 HOST_ORIGIN=https://example.com
+SP_DC=your_sp_dc_cookie_value

--- a/src/app.py
+++ b/src/app.py
@@ -1,9 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import os
-import asyncio
 import canvas
-from constants import TOKEN_RENEW_TIME
 
 app = FastAPI()
 
@@ -21,34 +19,19 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-access_token = ""
-
 @app.get('/api/canvas/{track_id}')
 def get_track_canvas(track_id):
     try:
+        access_token = canvas.get_access_token()
         canvas_url = canvas.get_canvas_for_track(access_token, track_id)
         return {'success': 'true', 'canvas_url': canvas_url}
     except AttributeError:
         return {'success': 'false', 'message': 'No canvas found for this track'}
     except ConnectionError:
-        return {'success': 'false', 'message': 'failed to connect to Spotify'}
+        return {'success': 'false', 'message': 'Failed to connect to Spotify'}
+    except Exception as e:
+        return {'success': 'false', 'message': f'Authentication error: {str(e)}'}
 
 @app.get('/api/health')
 def health():
     return "up"
-
-async def refresh_token():
-    global access_token
-    while True:
-        print('INFO:     Getting a fresh Spotify access token')
-
-        try:
-            access_token = canvas.get_access_token()
-        except Exception as e:
-            print('ERROR:   Failed to get a new access token: %s' % e)
-
-        await asyncio.sleep(TOKEN_RENEW_TIME)
-
-@app.on_event("startup")
-async def startup_event():
-    asyncio.get_event_loop().create_task(refresh_token())

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,145 @@
+import requests
+import time
+import hashlib
+import hmac
+import base64
+import struct
+import os
+from typing import Optional
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class SpotifyAuth:
+    def __init__(self):
+        self.access_token = None
+        self.expires_at = 0
+        self.sp_dc_cookie = os.getenv('SP_DC')
+        
+    def set_sp_dc_cookie(self, sp_dc: str):
+        """Set the sp_dc cookie required for authentication"""
+        self.sp_dc_cookie = sp_dc
+        
+    def base32_from_bytes(self, data: bytes, secret_sauce: str) -> str:
+        """Convert bytes to base32 using custom alphabet"""
+        t = 0
+        n = 0
+        r = ""
+        
+        for byte in data:
+            n = (n << 8) | byte
+            t += 8
+            while t >= 5:
+                r += secret_sauce[(n >> (t - 5)) & 31]
+                t -= 5
+                
+        if t > 0:
+            r += secret_sauce[(n << (5 - t)) & 31]
+            
+        return r
+    
+    def generate_totp(self) -> str:
+        """Generate TOTP for Spotify authentication"""
+        secret_sauce = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+        
+        # Secret cipher bytes from Spotify's implementation
+        secret_cipher_bytes = [12, 56, 76, 33, 88, 44, 88, 33, 78, 78, 11, 66, 22, 22, 55, 69, 54]
+        
+        # Apply the XOR transformation
+        transformed_bytes = [byte ^ (i % 33 + 9) for i, byte in enumerate(secret_cipher_bytes)]
+        
+        # Process the secret according to Spotify's algorithm
+        joined_string = "".join(str(byte) for byte in transformed_bytes)
+        utf8_bytes = joined_string.encode('utf-8')
+        hex_string = "".join(f"{byte:02x}" for byte in utf8_bytes)
+        secret_bytes = bytes.fromhex(hex_string)
+        
+        # Convert to base32
+        secret = self.base32_from_bytes(secret_bytes, secret_sauce)
+        
+        # Get server time from Spotify
+        try:
+            server_time_response = requests.get("https://open.spotify.com/server-time")
+            server_time_seconds = server_time_response.json()["serverTime"]
+        except:
+            server_time_seconds = int(time.time())
+        
+        # Generate TOTP
+        time_counter = server_time_seconds // 30
+        
+        # Add padding to secret if needed
+        missing_padding = len(secret) % 8
+        if missing_padding:
+            secret += '=' * (8 - missing_padding)
+        
+        try:
+            secret_bytes = base64.b32decode(secret.upper())
+        except Exception as e:
+            raise Exception(f"Failed to decode TOTP secret: {e}")
+        
+        # Generate HMAC-SHA1
+        time_bytes = struct.pack('>Q', time_counter)
+        hmac_digest = hmac.new(secret_bytes, time_bytes, hashlib.sha1).digest()
+        
+        # Dynamic truncation
+        offset = hmac_digest[-1] & 0x0F
+        truncated = struct.unpack('>I', hmac_digest[offset:offset + 4])[0]
+        truncated &= 0x7FFFFFFF
+        
+        # Generate 6-digit code
+        totp_value = truncated % (10 ** 6)
+        
+        return f"{totp_value:06d}"
+    
+    def get_access_token(self) -> str:
+        """Get access token using Spotify's authentication scheme"""
+        if not self.sp_dc_cookie:
+            raise Exception("sp_dc cookie is required. Set SP_DC environment variable or use set_sp_dc_cookie()")
+        
+        # Check if current token is still valid
+        if self.access_token and time.time() < self.expires_at:
+            return self.access_token
+        
+        try:
+            # Generate TOTP
+            totp = self.generate_totp()
+            timestamp = int(time.time())
+            
+            url = (
+                f"https://open.spotify.com/get_access_token"
+                f"?reason=transport"
+                f"&productType=web_player"
+                f"&totp={totp}"
+                f"&totpVer=5"
+                f"&ts={timestamp}"
+            )
+            
+            headers = {
+                "Cookie": f"sp_dc={self.sp_dc_cookie}",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+            }
+            
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            self.access_token = data["accessToken"]
+            self.expires_at = data["accessTokenExpirationTimestampMs"] / 1000
+            
+            return self.access_token
+            
+        except Exception as e:
+            raise Exception(f"Failed to get access token: {str(e)}")
+    
+    def is_authenticated(self) -> bool:
+        """Check if we have a valid access token"""
+        return self.access_token is not None and time.time() < self.expires_at
+
+
+_spotify_auth = SpotifyAuth()
+
+
+def get_access_token() -> str:
+    """Get access token - compatible with existing code"""
+    return _spotify_auth.get_access_token() 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -2,15 +2,7 @@ import requests
 import random
 from constants import *
 from protos.canvas_pb2 import EntityCanvazRequest, EntityCanvazResponse
-
-def get_access_token():
-    try:
-        response = requests.get(TOKEN_ENDPOINT)
-        data = response.json()
-        return data["accessToken"]
-    except Exception as e:
-        raise Exception(e)
-
+from auth import get_access_token
 
 def get_canvas_for_track(access_token, track_id):
     canvas_request = EntityCanvazRequest()

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,7 +1,5 @@
 API_HOST = "https://gew1-spclient.spotify.com"
 CANVAS_ROUTE = "/canvaz-cache/v0/canvases"
-TOKEN_ENDPOINT = "https://open.spotify.com/get_access_token?reason=transport"
-TOKEN_RENEW_TIME = 900
 
 TRACK_URI_PREFIX = "spotify:track:"
 OAUTH_SCOPES = "playlist-read"


### PR DESCRIPTION
This PR brings back the user account requirement due to Spotify API changes removing the unauthenticated token endpoint previously used by the web clients.

https://github.com/librespot-org/librespot/issues/1475


Reimplementing auth logic from https://github.com/KRTirtho/spotube/blob/59f298a935c87077a6abd50656f8a4ead44bd979/lib/provider/authentication/authentication.dart